### PR TITLE
fix(chart): expose pulsar service using LoadBalancer

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -14,13 +14,11 @@ This is the helm chart for installing FunctionStream on kubernetes.
 
     ```bash
     kubectl create namespace <k8s-namespace>
-
     ```
 3. Install the FunctionStream.
 
     ```bash
-    cd charts
-    helm install function-stream . -n <k8s-namespace>
+    helm install function-stream . -n <k8s-namespace> --values {Your values yaml file}
     ```
 
 4. Verify that the Function Stream is installed successfully.
@@ -38,7 +36,7 @@ This is the helm chart for installing FunctionStream on kubernetes.
 
 ## Uninstall
 
-Use the following command to uninstall FunctionMesh operator.
+* Use the following command to uninstall FunctionMesh operator.
 
     ```bash
     helm uninstall function-stream -n <k8s-namespace>

--- a/charts/templates/pulsar-services.yaml
+++ b/charts/templates/pulsar-services.yaml
@@ -31,3 +31,4 @@ spec:
     name: pulsar
   selector:
     app: pulsar
+  type: LoadBalancer


### PR DESCRIPTION
Currently, we cannot access the pulsar service within the cluster from outside.

This PR sets the service type to LoadBalancer to enable be accessed from outside. And fix some doc issues.