### PR TITLE
feat: update Function CRD to use packageRef instead of package field

### DIFF
--- a/operator/DEVELOPER.md
+++ b/operator/DEVELOPER.md
@@ -109,4 +109,17 @@ is manually re-applied afterwards.
 
 **NOTE:** Run `make help` for more information on all potential `make` targets
 
+### CRD Updates
+
+When CRD definitions are updated in `operator/config/crd/bases/`, you need to ensure the Helm chart CRD templates are also updated to match. The Helm chart CRD templates are located in `operator/deploy/chart/templates/crd/`.
+
+To update the Helm chart CRD templates:
+
+1. Update the CRD definitions in `operator/config/crd/bases/`
+2. Manually update the corresponding files in `operator/deploy/chart/templates/crd/` to match the base definitions
+3. Ensure any Helm-specific templating (like `{{- if .Values.crd.enable }}`) is preserved
+4. Test the changes to ensure the CRDs work correctly
+
+**Important:** The Helm chart CRD templates should always reflect the latest changes from the base CRD definitions to ensure consistency between direct CRD installation and Helm chart installation.
+
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)

--- a/operator/deploy/chart/templates/crd/fs.functionstream.github.io_functions.yaml
+++ b/operator/deploy/chart/templates/crd/fs.functionstream.github.io_functions.yaml
@@ -59,9 +59,18 @@ spec:
               module:
                 description: Module name
                 type: string
-              package:
-                description: Package name
-                type: string
+              packageRef:
+                description: Package reference
+                properties:
+                  name:
+                    description: Name of the Package resource
+                    type: string
+                  namespace:
+                    description: Namespace of the Package resource
+                    type: string
+                required:
+                - name
+                type: object
               replicas:
                 default: 1
                 description: Number of replicas for the function deployment
@@ -113,7 +122,7 @@ spec:
                 type: string
             required:
             - module
-            - package
+            - packageRef
             type: object
           status:
             description: FunctionStatus defines the observed state of Function


### PR DESCRIPTION
### Motivation

The Function CRD was using a simple `package` field as a string, which limited the ability to reference Package resources across namespaces and didn't follow Kubernetes best practices for resource references. This change updates the Function CRD to use a proper `packageRef` object that includes both name and namespace fields, allowing for better resource management and cross-namespace package references.

### Modifications

- **Updated Function CRD schema**: Changed the `package` field from a simple string to a `packageRef` object with `name` and `namespace` properties
- **Enhanced developer documentation**: Added a new section in `operator/DEVELOPER.md` explaining the process for updating CRD definitions and ensuring Helm chart templates stay in sync
- **Updated Helm chart templates**: Modified the CRD template in `operator/deploy/chart/templates/crd/fs.functionstream.github.io_functions.yaml` to reflect the new schema structure

The changes ensure that:
- Functions can now reference Package resources across different namespaces
- The CRD follows Kubernetes conventions for resource references
- Developers have clear guidance on maintaining CRD and Helm chart consistency
- Both direct CRD installation and Helm chart installation will have consistent behavior